### PR TITLE
Declare class method UIColor labelColor when compiling with Xcode < 1…

### DIFF
--- a/ios/QBImagePicker/QBImagePicker/QBAssetsViewController.m
+++ b/ios/QBImagePicker/QBImagePicker/QBAssetsViewController.m
@@ -14,6 +14,12 @@
 #import "QBAssetCell.h"
 #import "QBVideoIndicatorView.h"
 
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < 130000
+@interface UIColor (Xcode10)
++ (instancetype) labelColor;
+@end
+#endif
+
 static CGSize CGSizeScale(CGSize size, CGFloat scale) {
     return CGSizeMake(size.width * scale, size.height * scale);
 }


### PR DESCRIPTION
…1 (#1154)

The method was introduced in iOS 13.0 SDK.
We already call it within a runtime version check.